### PR TITLE
Add passReqToCallback option like other strategies

### DIFF
--- a/lib/passport-cas.js
+++ b/lib/passport-cas.js
@@ -44,6 +44,7 @@ var url = require('url')
  *   - `pgtURL`            Optional. URL of the PGT callback server (e.g. https://callback.example.com)
  *   - `sessionKey`        Optional. The name to use for storing CAS information within the `req.session` object. Default is 'cas'.
  *   - `propertyMap`       Optional. A basic key-value object for mapping extended user attributes from CAS to passport's profile format.
+ *   - `passReqToCallback` Optional. When `true`, `req` is the first argument to the verify callback (default: `false`)
  *
  * Example:
  *
@@ -82,6 +83,7 @@ function CasStrategy(options, verify) {
   Strategy.call(this);
   this.name = 'cas';
   this._verify = verify;
+  this._passReqToCallback = options.passReqToCallback;
   
   this.casBaseUrl = options.casURL;
   this.casPgtUrl = options.pgtURL || undefined;
@@ -235,7 +237,11 @@ CasStrategy.prototype.authenticate = function(req, options) {
           profile[key] = attributes[key];
         }
         
-        self._verify(username, profile, verified);
+        if (self._passReqToCallback) {
+          self._verify(req, username, profile, verified);
+        } else {
+          self._verify(username, profile, verified);
+        }
       }
         
     }, service);


### PR DESCRIPTION
Add passReqToCallback option to CasStrategy as documented in Passport (see http://passportjs.org/docs#association-in-verify-callback).  Many other strategies already implement this option to allow passing the req to the verify callback.  This was used as an example: https://github.com/jaredhanson/passport-local/blob/master/lib/strategy.js.
