### PR TITLE
router support

### DIFF
--- a/lib/passport-cas.js
+++ b/lib/passport-cas.js
@@ -119,7 +119,7 @@ CasStrategy.prototype.authenticate = function(req, options) {
   options = options || {};
   
   var self = this;
-  var reqURL = url.parse(req.url, true);
+  var reqURL = url.parse(req.originalUrl || req.url, true);
   var service;
   
   // `ticket` is present if user is already authenticated/authorized by CAS


### PR DESCRIPTION
If you use this strategy in a router, you get an error, because the req.url is without the router base part, so if you have /login/cas, the req.url is /cas
