### PR TITLE
router support

### DIFF
--- a/lib/passport-cas.js
+++ b/lib/passport-cas.js
@@ -119,7 +119,7 @@ CasStrategy.prototype.authenticate = function(req, options) {
   options = options || {};
   
   var self = this;
-  var reqURL = url.parse(req.url, true);
+  var reqURL = url.parse(req.originalUrl || req.url, true);
   var service;
   
   // `ticket` is present if user is already authenticated/authorized by CAS
@@ -151,7 +151,7 @@ CasStrategy.prototype.authenticate = function(req, options) {
             // `ticket` portion of the querystring remains after the
             // session times out and the user refreshes the page.
             // So remove the `ticket` and try again.
-            var url = req.url
+            var url = req.originalUrl || req.url
                 .replace(/_cas_retry=\d+&?/, '')
                 .replace(/([?&])ticket=[\w.-]+/, '$1_cas_retry='+token);
             self.redirect(url, 307);


### PR DESCRIPTION
adds req.originalUrl || before req.url, to support express router.

without this if the routers baseurl is /login and real url is /login/cas, the value of req.url is only /cas, so the cas server gives an error
