### PR TITLE
Fix infinite redirects caused by redirecting to URL without retry token

### DIFF
--- a/lib/passport-cas.js
+++ b/lib/passport-cas.js
@@ -151,7 +151,7 @@ CasStrategy.prototype.authenticate = function(req, options) {
             // `ticket` portion of the querystring remains after the
             // session times out and the user refreshes the page.
             // So remove the `ticket` and try again.
-            var url = req.originalUrl || req.url
+            var url = (req.originalUrl || req.url)
                 .replace(/_cas_retry=\d+&?/, '')
                 .replace(/([?&])ticket=[\w.-]+/, '$1_cas_retry='+token);
             self.redirect(url, 307);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-cas2",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "CAS 2.0 strategy for Passport.js authentication",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
If a ticket expires and `req.originalUrl` is defined, the string replacement operations that adds the retry token and removes the ticket value will not be executed or used causing an infinite redirect.

Regression introduced by #6 